### PR TITLE
pkp/pkp-lib#8340 Add pricing to purchase form (bootstrap port)

### DIFF
--- a/templates/frontend/pages/purchaseInstitutionalSubscription.tpl
+++ b/templates/frontend/pages/purchaseInstitutionalSubscription.tpl
@@ -33,7 +33,7 @@
 			</label>
 			<select name="typeId" id="typeId" class="form-control" required>
 				{foreach name=types from=$subscriptionTypes item=subscriptionType}
-					<option value="{$subscriptionType->getId()}"{if $typeId == $subscriptionType->getId()} selected{/if}>{$subscriptionType->getLocalizedName()|escape}</option>
+					<option value="{$subscriptionType->getId()}"{if $typeId == $subscriptionType->getId()} selected{/if}>{$subscriptionType->getSummaryString()|escape}</option>
 				{/foreach}
 			</select>
 		</div>


### PR DESCRIPTION
@NateWr, here is a port of pkp/pkp-lib#8340 to Bootstrap3, which contains a copy of the same template code as the default theme. This is suitable for both `master` and `stable-3_3_0` (but I've only opened the PR for `master`). (When you get a sec, I'd recommend renaming the branch to `main` as well -- or if you like, moving ownership over to PKP so we can distribute the management of the repo).