### PR TITLE
Display ORCID Icon only when authenticated

### DIFF
--- a/styles/bootstrap.less
+++ b/styles/bootstrap.less
@@ -77,6 +77,14 @@
         margin-bottom: 2em;
     }
 
+  .orcid_icon {
+    display: inline-block;
+    margin-right: 0.25em;
+    width: 24px;
+    height: 24px;
+    vertical-align: middle;
+  }
+
   .author + .author {
     margin-top: 0.5em;
   }

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -171,7 +171,9 @@
 								{/if}
 								{if $author->getOrcid()}
 									<div class="orcid">
-										{$orcidIcon}
+										{if $author->getData('orcidAccessToken')}
+											{$orcidIcon}
+										{/if}
 										<a href="{$author->getOrcid()|escape}" target="_blank">
 											{$author->getOrcid()|escape}
 										</a>


### PR DESCRIPTION
If I'm not wrong, in order to display the ORCID icon only when the user is authenticated, we need to add a condition, similar to what we have for the [default theme](https://github.com/pkp/ojs/blob/7e803f98b0fc90679e796eee69a9bfbed67849d4/templates/frontend/objects/article_details.tpl#L132).  Thank you.

ref: https://github.com/pkp/ojs/pull/3865
