### PR TITLE
fix pdf galley header for long titles

### DIFF
--- a/styles/bootstrap.less
+++ b/styles/bootstrap.less
@@ -214,7 +214,7 @@ footer[role="contentinfo"] {
 
 // Style the PDF and HTML view
 .header_view {
-	z-index: 2;
+	z-index: 0;
 	background: @navbar-default-bg;
   &:extend(.navbar all);
   &:extend(.navbar-default all);
@@ -241,6 +241,13 @@ footer[role="contentinfo"] {
     }
   }
 
+.header_view>.title {
+	overflow-x: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    display: block;
+}
+	
   .return,
   .download .label {
     &:extend(.sr-only all);


### PR DESCRIPTION
Hi there,

this commit tries to fix the display of long titles on small screens on the pdf galley view.

Suppose you have an article with a long title:

<img width="4394" height="694" alt="long title desktop" src="https://github.com/user-attachments/assets/e425a17b-89de-4155-a177-bb2630c926a4" />


Currently, it displays like this on small screens and therefore makes PDF controls unavailable (Download etc.).

<img width="1320" height="470" alt="long title mobile" src="https://github.com/user-attachments/assets/7eb3a354-2e62-4906-a782-7448032f8851" />


With this commit, it displays like this:

<img width="1308" height="484" alt="long title mobile new" src="https://github.com/user-attachments/assets/3a0a857e-8bc3-45a4-bde6-df8d89d23f51" />

Desktop view remains unchanged as far as I can see.

Best regards
Dennis
